### PR TITLE
Added a llink to the forum thread

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -16,6 +16,7 @@
         <platform>all</platform>
         <language/>
         <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
+        <forum>http://forum.kodi.tv/showthread.php?tid=209783</forum>
         <website/>
         <email/>
         <source>https://github.com/Amelandbor/service.subtitles.nlondertitels</source>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
